### PR TITLE
Update Get-WebCertificate function to work with powershell 7

### DIFF
--- a/Modules/Network/Network.psm1
+++ b/Modules/Network/Network.psm1
@@ -788,40 +788,37 @@ Function Get-MyIpAddress
 ### Web Functions ###
 
 
-Function Get-WebCertificate
-{
+Function Get-WebCertificate {
     <#
+        .Synopsis
+        Retrieve the details of a website's TLS certificate
 
-            .Synopsis
-            Retrieve the details of a website's TLS certificate
+        .DESCRIPTION
+        This cmdlet retrieves the TLS certificate information from a specified website or system using TCP client.
 
-            .DESCRIPTION
-            Long description
+        .EXAMPLE
+        Get-WebCertificate -HostName "example.com"
 
-            .EXAMPLE
-            Example of how to use this cmdlet
-
-            .EXAMPLE
-            Another example of how to use this cmdlet
+        .EXAMPLE
+        Get-WebCertificate -HostName "example.com", "example2.com" -Port 443
     #>
 
     <#
-            Version 0.?
-            - ???
+            Version 2.0
     #>
 
     [CmdLetBinding()]
     Param
     (
         [Parameter(Mandatory = $true, ValueFromPipeline = $true,
-        Position = 0, HelpMessage = 'Name or IP of system')]
-        [String[]] $System,
+            Position = 0, HelpMessage = 'Name or IP of system')]
+        [Alias("System")]
+        [String[]] $HostName,
         
         [int] $Port = 443
     )
     
-    Begin
-    {
+    Begin {
         # Baseline our environment 
         #Invoke-VariableBaseLine
 
@@ -829,75 +826,53 @@ Function Get-WebCertificate
         $Script:boolDebug = $PSBoundParameters.Debug.IsPresent
     }
     
-    Process
-    {
+    Process {
         # Variables
-        [int] $intTimeOutMilliseconds = 2500
         $objCerts = @()
-        
-        
-        Foreach ($objSystem in $System) 
-        {
-            # ensure that workin variables are clean. 
-            <#
-                    $request = $null 
-                    $cert = $null
-                    $dtExpiration = $null
-                    $certName = $null
-                    $intDaysRemaining = $null
-            #>
-            
-            # Must be working with a string name
-            If ($objSystem -notmatch 'https://')
-            {
-                [URI] $objSystem = 'https://{0}' -f $objSystem
-            }
-                
-            Else
-            {
-                
-            }
-            
-            # attempt to retrieve the server certificate
-            $request = $null
-            Remove-Variable -Name request -ErrorAction SilentlyContinue
-            $request = [Net.HttpWebRequest]::Create($objSystem)
-            $request.TimeOut = $intTimeOutMilliseconds
-            
-            Try
-            {
-                $request.GetResponse()
-            }
 
-            Catch 
-            {
-                Write-Debug -Message ('Unable to find {0}' -f $objSystem)
+        foreach ($objSystem in $HostName) {
+            # Remove http:// or https:// if present
+            $objSystem = $objSystem -replace '^https?://', ''
+
+            try {
+                $tcpClient = New-Object System.Net.Sockets.TcpClient($objSystem, $Port)
+                $sslStream = New-Object System.Net.Security.SslStream($tcpClient.GetStream(), $false, 
+                    { param ($certificate, $chain, $sslPolicyErrors)
+                        return $true 
+                    })
+                $sslStream.AuthenticateAsClient($objSystem)
+                $cert = $sslStream.RemoteCertificate
+
+                if ($cert) {
+                    $certDetails = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($cert)
+
+                    $objBuilder = New-Object -TypeName PSObject
+                    $objBuilder | Add-Member -MemberType NoteProperty -Name 'URI' -Value $objSystem
+                    $objBuilder | Add-Member -MemberType NoteProperty -Name 'Name' -Value $certDetails.GetName()
+                    $objBuilder | Add-Member -MemberType NoteProperty -Name 'CommonName' -Value ($certDetails.Subject -replace '.*CN=', '').Split(',')[0]
+                    $objBuilder | Add-Member -MemberType NoteProperty -Name 'EffectiveDate' -Value $certDetails.NotBefore
+                    $objBuilder | Add-Member -MemberType NoteProperty -Name 'EndDate' -Value $certDetails.NotAfter
+                    $objBuilder | Add-Member -MemberType NoteProperty -Name 'RemainingDays' -Value (($certDetails.NotAfter - (Get-Date)).Days)
+                    $objBuilder | Add-Member -MemberType NoteProperty -Name 'SHA1' -Value $certDetails.GetCertHashString()
+                    $objBuilder | Add-Member -MemberType NoteProperty -Name 'KeyAlgorithm' -Value $certDetails.PublicKey.Oid.FriendlyName
+                    $objBuilder | Add-Member -MemberType NoteProperty -Name 'SerialNumber' -Value $certDetails.SerialNumber
+                    $objBuilder | Add-Member -MemberType NoteProperty -Name 'Subject' -Value $certDetails.Subject
+                    $objBuilder | Add-Member -MemberType NoteProperty -Name 'Issuer' -Value $certDetails.Issuer
+                    $objBuilder | Add-Member -MemberType NoteProperty -Name 'Handle' -Value $certDetails.Handle
+                    $objBuilder | Add-Member -MemberType NoteProperty -Name 'Format' -Value $certDetails.GetFormat()
+
+                    # Append our cert object
+                    $objCerts += $objBuilder
+                }
+                else {
+                    Write-Output "No certificate information was captured for $objSystem."
+                }
+
+                $sslStream.Close()
+                $tcpClient.Close()
             }
-            
-            If ($request.ServicePoint.Certificate.Subject -ne $null)
-            {
-                $strCertName = $request.ServicePoint.Certificate.GetName()
-                $strCommonName = $strCertName.Split(' ') -Match 'CN=' -replace 'CN='
-                [DateTime]$dtExpiration = $request.ServicePoint.Certificate.GetExpirationDateString()
-                [int]$intDaysRemaining = ($dtExpiration - $(get-date)).Days
-            
-                $objBuilder = New-Object -TypeName PSObject 
-                $objBuilder | Add-Member -MemberType NoteProperty -Name 'URI' -Value $objSystem
-                $objBuilder | Add-Member -MemberType NoteProperty -Name 'Name' -Value $strCertName
-                $objBuilder | Add-Member -MemberType NoteProperty -Name 'CommonName' -Value $strCommonName
-                $objBuilder | Add-Member -MemberType NoteProperty -Name 'EffectiveDate' -Value $request.ServicePoint.Certificate.GetEffectiveDateString()
-                $objBuilder | Add-Member -MemberType NoteProperty -Name 'EndDate' -Value $request.ServicePoint.Certificate.GetExpirationDateString()
-                $objBuilder | Add-Member -MemberType NoteProperty -Name 'RemainingDays' -Value $intDaysRemaining
-                $objBuilder | Add-Member -MemberType NoteProperty -Name 'SHA1' -Value $request.ServicePoint.Certificate.GetSerialNumberString()
-                $objBuilder | Add-Member -MemberType NoteProperty -Name 'KeyAlgorithm' -Value $request.ServicePoint.Certificate.GetKeyAlgorithm()
-                $objBuilder | Add-Member -MemberType NoteProperty -Name 'SerialNumber' -Value $request.ServicePoint.Certificate.GetSerialNumberString()
-                $objBuilder | Add-Member -MemberType NoteProperty -Name 'Subject' -Value $request.ServicePoint.Certificate.Subject
-                $objBuilder | Add-Member -MemberType NoteProperty -Name 'Issuer' -Value $request.ServicePoint.Certificate.GetIssuerName()
-                $objBuilder | Add-Member -MemberType NoteProperty -Name 'Handle' -Value $request.ServicePoint.Certificate.Handle
-                $objBuilder | Add-Member -MemberType NoteProperty -Name 'Format' -Value $request.ServicePoint.Certificate.GetFormat()
-            
-                # Append our cert object
-                $objCerts += $objBuilder
+            catch {
+                Write-Error "Failed to retrieve certificate for $objSystem"
             }
         }
 
@@ -905,8 +880,7 @@ Function Get-WebCertificate
         $objCerts
     }
     
-    End
-    {
+    End {
         # Clean up the environment
         #Invoke-VariableBaseLine -Clean
     }


### PR DESCRIPTION
Due to the changes to [Net.HttpWebRequest], it no longer returns certificate information with the request.

To fix this, we must replace the usage of [Net.HttpWebRequest] with a method using System.Net.Sockets.TcpClient and System.Net.Security.SslStream. This approach allows us to directly establish a TCP connection to the target server and retrieve its SSL/TLS certificate using SslStream.RemoteCertificate.

This solution works in PowerShell 7, and Windows Powershell 5.1. Additionally, these changes ensure cross-platform compatibility, as it uses .NET Core's supported classes.

To learn more about the deprecation of this class please checkout these links:

- https://learn.microsoft.com/en-us/dotnet/api/system.net.httpwebrequest?view=net-8.0
- https://learn.microsoft.com/en-us/dotnet/core/compatibility/networking/6.0/webrequest-deprecated